### PR TITLE
OctoPrint: auto_uart to uart.

### DIFF
--- a/octoprint/config.json
+++ b/octoprint/config.json
@@ -16,7 +16,7 @@
         "5000/tcp": "WebUI (Not required for Ingress)",
         "8000/tcp": "mjpg-streamer (could also use WebUI/webcam/)"
     },
-    "auto_uart": true,
+    "uart": true,
     "homeassistant": "0.108.0",
     "map": ["config:rw"],
     "options": {

--- a/octoprint_dev/config.json
+++ b/octoprint_dev/config.json
@@ -19,7 +19,7 @@
     "devices": [
         "/dev/mem:/dev/mem:rw"
     ],
-    "auto_uart": true,
+    "uart": true,
     "homeassistant": "0.108.0",
     "privileged": ["SYS_RAWIO"],
     "map": ["config:rw"],

--- a/octoprint_slim/config.json
+++ b/octoprint_slim/config.json
@@ -15,7 +15,7 @@
         "5000/tcp": "OctoPrint WebUI"
     },
     "host_network": false,
-    "auto_uart": true,
+    "uart": true,
     "map": ["config:rw"],
     "options": {},
     "schema": {},


### PR DESCRIPTION
Change `auto_uart` to `uart` for OctoPrint, due to deprecation notice.