### PR TITLE
Change python3-dev to python3 for Octoprint

### DIFF
--- a/3dprinter/Dockerfile
+++ b/3dprinter/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "Install common dependencies" \
         linux-headers \
         postgresql-dev \
         py3-virtualenv \
-        python3-dev \
+        python3 \
         ## mjpg-streamer \
         libjpeg-turbo-dev \
         git \
@@ -57,7 +57,7 @@ RUN echo "Install OctoPrint" \
         linux-headers \
         postgresql-dev \
         py3-virtualenv \
-        python3-dev \
+        python3 \
     && echo "Done with apk add"
 RUN echo "Install" \
     && virtualenv --python=python3 /data/python/octoprint \


### PR DESCRIPTION
With version 1.8.0 of Octoprint, python 2 support drops. Changed python3-dev to python3 for latest python3 version.